### PR TITLE
fix: ensure nf-dotenv handles duplicate env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .gradle
 .idea
+.java-version
 .nextflow*
 build/
 out/

--- a/plugins/nf-dotenv/build.gradle
+++ b/plugins/nf-dotenv/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     compileOnly 'org.pf4j:pf4j:3.4.1'
 
     // Plugin dependencies.
-    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    implementation 'io.github.cdimascio:dotenv-java:3.2.0'
 
     // Test configuration.
     testImplementation "io.nextflow:nextflow:$nextflowVersion"

--- a/plugins/nf-dotenv/src/main/nextflow/dotenv/DotenvExtension.groovy
+++ b/plugins/nf-dotenv/src/main/nextflow/dotenv/DotenvExtension.groovy
@@ -41,12 +41,13 @@ class DotenvExtension extends PluginExtensionPoint {
                 .filename(this.filename)
                 .directory(this.directory.toString())
                 .load()
-        } catch (DotenvException) {
+        } catch (DotenvException originalException) {
             throw new DotenvException(
                 "Could not find dotenv file at path ${this.directory}/${this.filename}\n\n" +
                 "Consider modifying the following properties in your Nextflow config:\n\n" +
                 "\tdotenv.filename = '${DEFAULT_FILENAME}'\n" +
-                "\tdotenv.relative = '.'\n\n"
+                "\tdotenv.relative = '.'\n\n" +
+                "Original `dotenv` parsing error: ${originalException.message}"
             )
         }
     }()

--- a/plugins/nf-dotenv/src/test/nextflow/dotenv/DotenvTest.groovy
+++ b/plugins/nf-dotenv/src/test/nextflow/dotenv/DotenvTest.groovy
@@ -191,4 +191,21 @@ class DotenvTest extends Dsl2Spec{
         then:
             thrown DotenvException
     }
+
+    def 'should allow for duplicate variables in the dotenv file, preferring the last one defined' () {
+        when:
+            String SCRIPT = '''
+                include { dotenv } from 'plugin/nf-dotenv'
+                channel.of(dotenv('FOO'))
+            '''
+            String DOTENV = '''
+                FOO=bar1
+                FOO=bar2
+            '''
+        and:
+            def result = new MockScriptRunner([:]).setScript(SCRIPT).setDotenv(DOTENV).execute()
+        then:
+            result.val == 'bar2'
+            result.val == Channel.STOP
+    }
 }


### PR DESCRIPTION
This turned out to be an issue in the underlying dotenv parser and was fixed in 3.2.0:

- https://github.com/cdimascio/dotenv-java/pull/85

Closes #17 